### PR TITLE
Prevent infinite loop for chats whose first message id is not 0 or 1

### DIFF
--- a/telegram_messages_dump/telegram_dumper.py
+++ b/telegram_messages_dump/telegram_dumper.py
@@ -206,8 +206,8 @@ class TelegramDumper(TelegramClient):
             :param peer:        Chat/Channel object
             :param buffer:      buffer where to place retrieved messages
 
-            :return
-                latest_message_id The latest/biggest Message ID that sucessfully went into buffer.
+            :return The latest/biggest Message ID that successfully went into buffer,
+                    or -1 if there are no more messages.
         """
         messages = []
 
@@ -309,8 +309,9 @@ class TelegramDumper(TelegramClient):
                 if len(buffer) >= 1000:
                     self._flush_buffer_in_temp_file(buffer)
                     temp_files_list_meta.append(latest_message_id_fetched)
+
                 # break if the very beginning of channel history is reached
-                if self.id_offset <= 1:
+                if latest_message_id_fetched == -1 or self.id_offset <= 1:
                     break
         except RuntimeError as ex:
             sprint('Fetching messages from server failed. ' + str(ex))

--- a/telegram_messages_dump/telegram_dumper.py
+++ b/telegram_messages_dump/telegram_dumper.py
@@ -238,9 +238,8 @@ class TelegramDumper(TelegramClient):
         # Iterate over all (in reverse order so the latest appear
         # the last in the console) and print them with format provided by exporter.
         for msg in messages:
-            self.exporter_context.is_first_record = True \
-                if self.msg_count_to_process == 1 \
-                else False
+            self.exporter_context.is_first_record = \
+                self.msg_count_to_process == 1
 
             if self.settings.last_message_id >= msg.id:
                 self.msg_count_to_process = 0


### PR DESCRIPTION
Check the latest_message_id_fetched since it will be -1 if there are no more messages to retrieve. This could occur if the first message in the chat has an id > 1. Likely fixes #21 #22 #28.

## Background
I tried dumping a chat with 16800~ messages, but it started looping infinitely after it processed messages 140-16800. It got stuck after `Processing messages with ids 139-135 ...`.

After applying the fixes in the PR, I realized that the first message in the chat had id 135. Once the program got to line 297, `_fetch_messages_from_server` continued returning -1 since there were no more messages. Since there were no more messages, lines 240-256 never executed again and never set `self.id_offset` to below 1. The value of `self.id_offset` was stuck at 135. So `self.id_offset <= 1` was never true, so it kept looping from line 293-314.