### PR TITLE
update telethon version for python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email='kostikkv@gmail.com',
     url='https://github.com/Kosat/telegram-messages-dump',
     download_url='https://github.com/Kosat/telegram-messages-dump/releases',
-    install_requires=['telethon==1.6.2'],
+    install_requires=['telethon==1.24.0'],
     license="MIT",
     packages=['telegram_messages_dump', "telegram_messages_dump.exporters"],
     include_package_data=True,


### PR DESCRIPTION
Doesn't work with interpreter version 3.10.
The following error occurs:

> Try to load exporter 'text.py'...  OK!
> INFO:Initializing session...
> Traceback (most recent call last):
>   File "/home/asd/project/asd/venv/bin/telegram-messages-dump", line 8, in <module>
>     sys.exit(main())
>   File "/home/asd/project/asd/venv/lib/python3.10/site-packages/telegram_messages_dump/run.py", line 61, in main
>     sys.exit(TelegramDumper(os.path.basename(__file__), settings, metadata, exporter).run())
>   File "/home/asd/project/asd/venv/lib/python3.10/site-packages/telegram_messages_dump/telegram_dumper.py", line 36, in __init__
>     super().__init__(session_user_id,
>   File "/home/asd/project/asd/venv/lib/python3.10/site-packages/telethon/client/telegrambaseclient.py", line 272, in __init__
>     self._sender = MTProtoSender(
>   File "/home/asd/project/asd/venv/lib/python3.10/site-packages/telethon/network/mtprotosender.py", line 97, in __init__
>     self._send_queue = MessagePacker(self._state, self._loop,
>   File "/home/asd/project/asd/venv/lib/python3.10/site-packages/telethon/extensions/messagepacker.py", line 29, in __init__
>     self._ready = asyncio.Event(loop=loop)
>   File "/usr/lib/python3.10/asyncio/locks.py", line 168, in __init__
>     super().__init__(loop=loop)
>   File "/usr/lib/python3.10/asyncio/mixins.py", line 17, in __init__
>     raise TypeError(
> TypeError: As of 3.10, the *loop* parameter was removed from Event() since it is no longer necessary
> 

To solve the problem, you need to update the version of telethon